### PR TITLE
fix: 튀어나오는 글자 수정

### DIFF
--- a/src/components/button/commonButton.tsx
+++ b/src/components/button/commonButton.tsx
@@ -25,21 +25,21 @@ const CommonButton = ({
 }: CommonButtonProps) => {
   const hasIcon = variant === "social-google" || variant === "social-kakao";
   const baseStyle =
-    "flex items-center justify-center text-center cursor-pointer ";
+    "flex items-center justify-center text-center cursor-pointer whitespace-nowrap tablet:whitespace-nowrap";
 
   const variantStyles: Record<ButtonVariant, string> = {
     "social-google":
-      "w-303 h-48 gap-[10px] py-14 rounded-[12px] text-md text-gray-800 border border-gray-300 bg-white font-medium tablet:w-400 tablet:h-52 tablet:gap-12 tablet:text-lg",
+      "w-303 h-48 gap-10 px-81.5 py-14 rounded-[12px] text-md text-gray-800 border border-gray-300 bg-white font-medium tablet:w-400 tablet:h-52 tablet:gap-12 tablet:text-lg",
     "social-kakao":
-      "w-303 h-48 gap-[10px] py-14 rounded-[12px] text-md text-gray-800 border border-gray-300 bg-white font-medium tablet:w-400 tablet:h-52 tablet:gap-12 tablet:text-lg",
+      "w-303 h-48 gap-10 py-14 px-81.5 rounded-[12px] text-md text-gray-800 border border-gray-300 bg-white font-medium tablet:w-400 tablet:h-52 tablet:gap-12 tablet:text-lg",
     "modal-cancel":
       "w-61 h-40 px-18 py-16 rounded-[12px] text-md text-gray-500 border border-gray-300 bg-white font-medium tablet:w-68 tablet:h-42 tablet:px-20 tablet:text-lg",
     "modal-submit":
-      "w-100 h-40 px-18 py-16 rounded-[12px] text-md text-white bg-primary-purple font-bold border-none tablet:w-113 tablet:h-42 tablet:px-20 tablet:text-lg",
+      "w-100 h-40 px-18 py-16 rounded-[12px] text-md text-white bg-main font-bold border-none tablet:w-113 tablet:h-42 tablet:px-20 tablet:text-lg ",
     signup:
-      "w-343 h-48 px-172 py-16 rounded-[12px] text-md text-white bg-primary-purple font-bold tablet:w-400 tablet:h-50 tablet:rounded-[16px] tablet:text-lg",
+      "w-343 h-48 px-172 py-16 rounded-[12px] text-md text-white bg-main font-bold tablet:w-400 tablet:h-50 tablet:rounded-[16px] tablet:text-lg",
     review:
-      "w-169 h-48 px-48 py-16 rounded-[12px] text-white bg-primary-purple font-semibold text-lg",
+      "w-169 h-48 px-48 py-16 rounded-[12px] text-white bg-main font-semibold text-lg",
   };
 
   return (


### PR DESCRIPTION
버튼 ui에 부족한 점들을 수정하였습니다.
1. 글자가 세로로 써짐
2. 가로길이가 뒤죽박죽됨
3. 아이콘이 안나옴

## 📝 PR 내용 요약
어떤 작업을 했는지 간단히 요약해주세요.
- whitespace-nowrap tablet:whitespace-nowrap을 추가하여 해결하였습니다.
- 구글과 카카오에 패딩x값이 없어서 추가하였습니다.
- 아직 아이콘에 대해 구현하지 못하였습니다, 차후 수정하여 해결하겠습니다.

---

## 🧩 관련 이슈
관련된 이슈 번호를 적어주세요.  
자동으로 닫으려면 `Close #이슈번호` 형태로 작성합니다.

예:  
Close #161

---

## 📸 스크린샷 (선택)
UI 변경이 있는 경우 캡처를 첨부해주세요.
![image](https://github.com/user-attachments/assets/13a43baa-4ff5-4275-b895-7f1d546d795d)

---
